### PR TITLE
Export globally `mocha` and `runner` instances

### DIFF
--- a/lib/ipc.js
+++ b/lib/ipc.js
@@ -3,12 +3,13 @@
 const {remote, ipcRenderer} = require("electron");
 const EVENT_CLOSE_PROJECT   = "atom-mocha:close-project";
 const EVENT_JUMP_TO_FILE    = "atom-mocha:jump-to-file";
+const VAR_CMD_MANAGER = 'AtomMochaCmdManager';
 
 
 class IPC{
 	
 	init(projectPath){
-		global.AtomMocha = {};
+		global[ VAR_CMD_MANAGER ] = {};
 		this.projectPath = projectPath;
 		this.injectHooks();
 	}
@@ -36,14 +37,14 @@ class IPC{
 	
 	
 	getInjectedCode(path){
-		return "if(global.atom && null == global.AtomMocha && " + 
-		`-1 !== global.atom.project.getPaths().indexOf("${ path }")){
+		return `if(global.atom && null == global.${ VAR_CMD_MANAGER } &&
+		-1 !== global.atom.project.getPaths().indexOf("${ path }")){
 			const {remote, ipcRenderer} = require("electron");
 			const {Range} = require("atom");
 			
-			const AtomMocha = {
+			const ${ VAR_CMD_MANAGER } = {
 				handleJump(event, ...args){
-					AtomMocha.jumpToFile(...args);
+					${ VAR_CMD_MANAGER }.jumpToFile(...args);
 				},
 				jumpToFile(file, row, col){
 					atom.project.contains(file) && atom.workspace.open(file).then(editor => {
@@ -56,11 +57,11 @@ class IPC{
 				}
 			};
 			
-			global.AtomMocha = AtomMocha;
-			remote.ipcMain.on("${ EVENT_JUMP_TO_FILE }", AtomMocha.handleJump);
+			global.${ VAR_CMD_MANAGER } = ${ VAR_CMD_MANAGER };
+			remote.ipcMain.on("${ EVENT_JUMP_TO_FILE }", ${ VAR_CMD_MANAGER }.handleJump);
 			window.addEventListener("beforeunload", () => {
 				ipcRenderer.send("${ EVENT_CLOSE_PROJECT }", "${ path }");
-				remote.ipcMain.removeListener("${ EVENT_JUMP_TO_FILE }", AtomMocha.handleJump);
+				remote.ipcMain.removeListener("${ EVENT_JUMP_TO_FILE }", ${ VAR_CMD_MANAGER }.handleJump);
 			});
 		}`;
 	}

--- a/lib/main.js
+++ b/lib/main.js
@@ -23,14 +23,17 @@ class AtomMocha{
 		this.options.noExtensions || require("./extensions");
 		
 		// Talk to Mocha
-		this.runner   = new Mocha(this.options);
-		this.reporter = this.runner._reporter;
+		this.mocha = new Mocha(this.options);
+		this.reporter = this.mocha._reporter;
 		
 		// Tell it what specs to load
-		this.files.forEach(s => this.runner.addFile(s));
+		this.files.forEach(s => this.mocha.addFile(s));
 		
 		// Finally, initialise Atom's test environment
 		this.setup(args);
+		
+		// Globalise `AtomMocha` instance.
+		global.AtomMocha = this;
 	}
 	
 	
@@ -517,7 +520,7 @@ class AtomMocha{
 		run = run.then(this.attachAssets(this.options));
 		
 		return run.then(_=> new Promise(resolve =>
-			this.runner.run(failures => resolve(failures))
+			(this.runner = this.mocha.run(failures => resolve(failures)))
 		));
 	}
 }


### PR DESCRIPTION
First of all, thank you very much for your efforts and making this awesome package open source!

I'm using it to get code coverage for my Atom package, and I need the `mocha` and `runner` instances available to hook my coverage collector into them.

As you can see, the changes are minimal and doesn't change any default functionality.

[Here](https://stackoverflow.com/questions/18660916/#answer-18702655) you can read about those hooks I need. Summarizing:

- Runner events, which I can subscribe like `global.mocha.runner.on('end', cb)` with this PR.
- Mocha instance hooks, which I can hook into like `global.mocha.instance.beforeAll(cb)` with this PR.

Hope you found it useful and merge it to this awesome package.

I'm here for any improvements/corrections/issues you may have!